### PR TITLE
feat: Windows terminal via pywinpty ConPTY (fixes subprocess.Popen approach)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,92 @@ else:
     signal = None
     resource = None
 
+
+class WindowsTerminal:
+    """Manages a ConPTY session connected via WebSocket on Windows.
+
+    Uses pywinpty (ConPTY) for proper terminal emulation.
+    """
+
+    def __init__(self):
+        self.process = None
+        self.running = False
+        self._read_threads = []
+
+    def spawn(self, command=None, dimensions=(24, 80)):
+        """Spawn a new ConPTY process with the given command."""
+        try:
+            from winpty import PtyProcess
+        except ImportError:
+            print("[Claude Code] pywinpty not installed - run: pip install pywinpty")
+            return False
+
+        if not command:
+            command = "cmd.exe"
+
+        # Split command string into args
+        if isinstance(command, str):
+            parts = command.split()
+            cmd_exe = parts[0]
+            # .CMD files must be run via cmd /c
+            if cmd_exe.lower().endswith('.cmd'):
+                args = ["cmd", "/c"] + parts
+            else:
+                args = parts
+        else:
+            args = command
+
+        try:
+            self.process = PtyProcess.spawn(args, dimensions=dimensions)
+            self.running = True
+            return True
+        except Exception as e:
+            print(f"[Claude Code] Failed to spawn ConPTY process: {e}")
+            return False
+
+    def resize(self, rows, cols):
+        """Resize the ConPTY."""
+        if self.process and self.running:
+            try:
+                self.process.setwinsize(rows, cols)
+            except Exception:
+                pass
+
+    def write(self, data):
+        """Write data to the ConPTY."""
+        if not self.running or not self.process:
+            return
+        try:
+            self.process.write(data)
+        except (OSError, EOFError):
+            self.running = False
+
+    def read(self, nbytes=4096):
+        """Blocking read from the ConPTY. Returns str or None on EOF."""
+        if not self.running or not self.process:
+            return None
+        try:
+            data = self.process.read(nbytes)
+            if isinstance(data, bytes):
+                return data.decode("utf-8", errors="replace")
+            return data
+        except EOFError:
+            self.running = False
+            return None
+        except Exception:
+            return None
+
+    def close(self):
+        """Terminate the ConPTY process."""
+        self.running = False
+        if self.process:
+            try:
+                self.process.terminate(force=True)
+            except Exception:
+                pass
+            self.process = None
+
+
 WEB_DIRECTORY = "./js"
 
 NODE_CLASS_MAPPINGS = {}
@@ -522,12 +608,121 @@ async def websocket_handler(request):
     await ws.prepare(request)
 
     if IS_WINDOWS:
-        # Send a message indicating terminal is not supported on Windows
-        await ws.send_str(json.dumps({
-            "type": "error",
-            "message": "Terminal not supported on Windows. Use Clawdbot or Claude Code CLI directly."
-        }))
-        await ws.close()
+        session_id = id(ws)
+        terminal = WindowsTerminal()
+        terminal_sessions[session_id] = terminal
+        terminal_started = False
+
+        print(f"[Claude Code] WebSocket connected (Windows): {session_id}")
+        log_memory("ws connect")
+
+        command = request.query.get("cmd", None)
+        if command is None:
+            command = get_claude_command()
+            print(f"[Claude Code] Auto-detected command: {command}")
+
+        if command in ("claude", "claude -c"):
+            print("[Claude Code] Claude CLI not found, attempting auto-install...")
+            success, message = install_claude_code()
+            if success:
+                command = get_claude_command()
+                print(f"[Claude Code] After install, command: {command}")
+
+        try:
+            setup_mcp_config()
+        except Exception as e:
+            print(f"[Claude Code] MCP setup error (non-fatal): {e}")
+
+        async def read_pipes():
+            """Read from ConPTY and send to WebSocket."""
+            import threading
+
+            loop = asyncio.get_event_loop()
+            output_queue = asyncio.Queue()
+
+            def reader():
+                """Thread that reads from ConPTY and pushes to the async queue."""
+                try:
+                    while terminal.running:
+                        text = terminal.read(4096)
+                        if text is None:
+                            break
+                        if text:
+                            loop.call_soon_threadsafe(output_queue.put_nowait, text)
+                except Exception:
+                    pass
+                finally:
+                    terminal.running = False
+                    loop.call_soon_threadsafe(output_queue.put_nowait, None)
+
+            pty_thread = threading.Thread(target=reader, daemon=True)
+            pty_thread.start()
+            terminal._read_threads = [pty_thread]
+
+            buffer = []
+            try:
+                while terminal.running and not ws.closed:
+                    try:
+                        item = await asyncio.wait_for(output_queue.get(), timeout=0.05)
+                        if item is None:
+                            break
+                        buffer.append(item)
+                        # Drain queue to batch sends
+                        while not output_queue.empty():
+                            item = output_queue.get_nowait()
+                            if item is None:
+                                break
+                            buffer.append(item)
+                        if buffer:
+                            await ws.send_str("o" + "".join(buffer))
+                            buffer.clear()
+                    except asyncio.TimeoutError:
+                        if buffer:
+                            await ws.send_str("o" + "".join(buffer))
+                            buffer.clear()
+            except Exception as e:
+                print(f"[Claude Code] Read error: {e}")
+
+        read_task = None
+
+        try:
+            async for msg in ws:
+                if msg.type == web.WSMsgType.TEXT:
+                    try:
+                        data = json.loads(msg.data)
+                        msg_type = data.get("type")
+
+                        if msg_type == "i":
+                            terminal.write(data.get("d", ""))
+                        elif msg_type == "input":
+                            terminal.write(data.get("data", ""))
+                        elif msg_type == "resize":
+                            rows = data.get("rows", 24)
+                            cols = data.get("cols", 80)
+
+                            if not terminal_started:
+                                if terminal.spawn(command, dimensions=(rows, cols)):
+                                    terminal_started = True
+                                    read_task = asyncio.create_task(read_pipes())
+                                    print(f"[Claude Code] Terminal started (Windows/ConPTY) with size {cols}x{rows}")
+                                else:
+                                    await ws.send_str("o\x1b[1;31mFailed to start terminal process.\x1b[0m\r\n")
+                                    break
+                            terminal.resize(rows, cols)
+                    except json.JSONDecodeError:
+                        pass
+                elif msg.type == web.WSMsgType.ERROR:
+                    print(f"[Claude Code] WebSocket error: {ws.exception()}")
+                    break
+        finally:
+            terminal.running = False
+            if read_task:
+                read_task.cancel()
+            terminal.close()
+            del terminal_sessions[session_id]
+            print(f"[Claude Code] WebSocket disconnected (Windows): {session_id}")
+            log_memory("ws disconnect")
+
         return ws
 
     session_id = id(ws)
@@ -660,7 +855,7 @@ async def mcp_status_handler(request):
                 "connected": True,
                 "tools": 15,  # Known tool count
                 "platform": "windows" if IS_WINDOWS else "unix",
-                "terminal_supported": not IS_WINDOWS
+                "terminal_supported": True
             })
         else:
             return web.json_response({
@@ -680,7 +875,7 @@ async def platform_info_handler(request):
     return web.json_response({
         "platform": sys.platform,
         "is_windows": IS_WINDOWS,
-        "terminal_supported": not IS_WINDOWS,
+        "terminal_supported": True,
         "python_version": sys.version,
         "comfyui_url": get_comfyui_url_cached()
     })
@@ -722,7 +917,7 @@ def setup_routes(app):
     print("[Claude Code] Memory stats endpoint registered at /claude-code/memory")
     print("[Claude Code] Platform info endpoint registered at /claude-code/platform")
     if IS_WINDOWS:
-        print("[Claude Code] Note: Terminal functionality disabled on Windows")
+        print("[Claude Code] Windows terminal support enabled (ConPTY mode)")
 
 
 def write_comfyui_url():
@@ -807,15 +1002,12 @@ try:
     # Write ComfyUI URL for MCP server
     write_comfyui_url()
 
-    # Set up MCP configuration (skip on Windows if claude not found)
-    if not IS_WINDOWS:
-        setup_mcp_config()
-    else:
-        print("[Claude Code] Skipping MCP auto-config on Windows (use Clawdbot instead)")
+    # Set up MCP configuration
+    setup_mcp_config()
 
     # Log initial memory usage
     mem_mb = get_memory_mb()
-    platform_note = " (Windows - terminal disabled)" if IS_WINDOWS else ""
+    platform_note = " (Windows - ConPTY mode)" if IS_WINDOWS else ""
     print(f"[Claude Code] Plugin loaded successfully{platform_note} (Memory: {mem_mb:.1f}MB)")
 except Exception as e:
     print(f"[Claude Code] Failed to register routes: {e}")


### PR DESCRIPTION
## Problem with PR #15's `subprocess.Popen` approach

PR #15 adds Windows terminal support using `subprocess.Popen` with `stdin/stdout/stderr` pipes. While the intent is correct, this approach does **not** create a real TTY. Claude Code detects it is not running in an interactive terminal and immediately falls back to `--print` mode:

```
Warning: no stdin data received in 3s, proceeding without it.
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

The WebSocket then disconnects. Tested on Windows 11 with ComfyUI via StabilityMatrix.

## Solution: pywinpty (Windows ConPTY)

[pywinpty](https://github.com/andfoy/pywinpty) wraps the Windows **ConPTY** API (available since Windows 10 1903) and provides a proper pseudo-terminal. Claude Code sees a real TTY and starts interactively.

This PR replaces `WindowsTerminal` with a ConPTY-based implementation. The Unix `WebSocketTerminal` code path is **unchanged**.

**New dependency:** `pywinpty` — requires Windows 10 1903+

## Changes

### `WindowsTerminal` class — rewritten around `PtyProcess`

- `spawn()` calls `PtyProcess.spawn(args, dimensions=dimensions)` — creates a real ConPTY
- `write()` passes `str` directly (`PtyProcess.write()` expects `str`, not `bytes`)
- `resize()` calls `process.setwinsize(rows, cols)` — actually works
- `read()` blocking read from the PTY (replaces stdout/stderr pipes)
- `close()` calls `process.terminate(force=True)`

### `websocket_handler` — Windows path updated

- `read_pipes()` uses a **single reader thread** (ConPTY merges stdout+stderr like a real terminal, replacing the two-thread approach)
- `spawn()` call now passes `dimensions=(rows, cols)` so the initial terminal size is correct

### Minor fixes

- Log messages updated from "subprocess mode" to "ConPTY mode"
- `terminal_supported: True` in status/platform endpoints (same as PR #15)
- `setup_mcp_config()` called unconditionally on Windows (same as PR #15)

## Comparison

| | PR #15 `subprocess.Popen` | This PR `pywinpty` ConPTY |
|---|---|---|
| Real TTY | ❌ | ✅ |
| Claude Code interactive | ❌ (falls back to `--print`) | ✅ |
| Terminal resize | ❌ no-op | ✅ `setwinsize` |
| stdout + stderr | 2 threads | 1 combined stream |
| `write()` input | `bytes` | `str` |
| Windows requirement | any | Windows 10 1903+ |

## Test plan

- [x] ComfyUI starts with log: `Windows terminal support enabled (ConPTY mode)`
- [x] Terminal connects in browser (no "Terminal disconnected")
- [x] Claude Code starts interactively in the embedded terminal
- [x] MCP tools work from Claude Code
- [ ] Unix/macOS behavior unchanged (no regressions — code path untouched)

---
*Diagnosed and implemented with AI*