### PR TITLE
Fix terminal WebSocket disconnects and env variable inheritance

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -519,7 +519,7 @@ async def run_node_handler(request):
 
 async def websocket_handler(request):
     """Handle WebSocket connections for terminal sessions."""
-    ws = web.WebSocketResponse()
+    ws = web.WebSocketResponse(heartbeat=30.0)
     await ws.prepare(request)
 
     if IS_WINDOWS:

--- a/__init__.py
+++ b/__init__.py
@@ -233,6 +233,7 @@ class WebSocketTerminal:
         if self.pid == 0:
             # Child process
             env = os.environ.copy()
+            env.pop("CLAUDECODE", None)
             env["TERM"] = "xterm-256color"
             env["COLORTERM"] = "truecolor"
 

--- a/js/claude-code.js
+++ b/js/claude-code.js
@@ -6,6 +6,7 @@ let terminal = null;
 let fitAddon = null;
 let websocket = null;
 let claudeRunning = false;
+let keepaliveInterval = null;
 
 app.registerExtension({
     name: "comfy.claude-code",
@@ -680,6 +681,14 @@ function connectWebSocket() {
         websocket.onopen = () => {
             console.log("[Claude Code] WebSocket connected");
 
+            // Start keepalive ping every 25 seconds to prevent idle disconnect
+            if (keepaliveInterval) clearInterval(keepaliveInterval);
+            keepaliveInterval = setInterval(() => {
+                if (websocket && websocket.readyState === WebSocket.OPEN) {
+                    websocket.send(JSON.stringify({ type: "ping" }));
+                }
+            }, 25000);
+
             // Clear terminal first
             terminal.clear();
 
@@ -732,6 +741,10 @@ function connectWebSocket() {
 
         websocket.onclose = (event) => {
             console.log("[Claude Code] WebSocket closed:", event.code, event.reason);
+            if (keepaliveInterval) {
+                clearInterval(keepaliveInterval);
+                keepaliveInterval = null;
+            }
             terminal.writeln("\n\x1b[1;31mTerminal disconnected.\x1b[0m");
             terminal.writeln("Click ↻ to reload.\n");
         };


### PR DESCRIPTION
 ## Summary
  - Fix WebSocket connections dropping during long idle periods by adding
    server-side heartbeat (30s) and client-side keepalive pings (25s)
  - Remove `CLAUDECODE` env variable from child process to prevent
    inheritance issues in spawned terminal sessions

  ## Test plan
  - [ ] Open a terminal session and leave it idle for several minutes — verify it stays connected
  - [ ] Confirm Claude Code launches correctly without inheriting stale `CLAUDECODE` variable
  - [ ] Verify WebSocket reconnect UI still works after an actual disconnect