### PR TITLE
Enable auto mode when launching Claude Code

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -193,15 +193,15 @@ def get_claude_command(working_dir=None):
     claude_path = find_executable("claude")
     if claude_path:
         if has_claude_conversation(working_dir):
-            return f"{claude_path} -c --enable-auto-mode"
+            return f"{claude_path} -c --permission-mode auto"
         else:
-            return f"{claude_path} --enable-auto-mode"
+            return f"{claude_path} --permission-mode auto"
     else:
         # Fallback - let the shell try to find it
         if has_claude_conversation(working_dir):
-            return "claude -c --enable-auto-mode"
+            return "claude -c --permission-mode auto"
         else:
-            return "claude --enable-auto-mode"
+            return "claude --permission-mode auto"
 
 
 class WebSocketTerminal:

--- a/__init__.py
+++ b/__init__.py
@@ -193,15 +193,15 @@ def get_claude_command(working_dir=None):
     claude_path = find_executable("claude")
     if claude_path:
         if has_claude_conversation(working_dir):
-            return f"{claude_path} -c"
+            return f"{claude_path} -c --enable-auto-mode"
         else:
-            return claude_path
+            return f"{claude_path} --enable-auto-mode"
     else:
         # Fallback - let the shell try to find it
         if has_claude_conversation(working_dir):
-            return "claude -c"
+            return "claude -c --enable-auto-mode"
         else:
-            return "claude"
+            return "claude --enable-auto-mode"
 
 
 class WebSocketTerminal:


### PR DESCRIPTION
## Summary
- Launch Claude Code with `--permission-mode auto` so MCP tool calls (workflow reads, edits, node operations) are auto-approved by Claude's safety classifier
- Users can still cycle permission modes with `Shift+Tab` in-session

## Context
Claude Code now supports [auto mode](https://claude.com/blog/auto-mode), which sits between conservative defaults and `--dangerously-skip-permissions`. A classifier auto-approves safe actions and blocks destructive ones — a good fit for ComfyUI MCP tools which are all safe workflow operations. Requires Claude Code v2.1.83+.

## Test plan
- [ ] Launch ComfyUI with the plugin
- [ ] Open the Claude Code terminal
- [ ] Confirm Claude starts in auto mode (visible in status line)
- [ ] Ask Claude to use an MCP tool (e.g. get the workflow) — should auto-accept
- [ ] Verify `Shift+Tab` cycles to other permission modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)